### PR TITLE
Update planarfactory.txt

### DIFF
--- a/doc/planarfactory.txt
+++ b/doc/planarfactory.txt
@@ -2,7 +2,7 @@ PLANAR GRAPH GENERATORS
 ----------------------------------------------------------------------
 from graphtheory.structures.edges import Edge
 from graphtheory.structures.graphs import Graph
-from graphtheory.structures.planarfactory import PlanarGraphFactory
+from graphtheory.planarity.planarfactory import PlanarGraphFactory
 
 gf = PlanarGraphFactory(Graph)
 


### PR DESCRIPTION
To fix the `ModuleNotFoundError` error 

```bash
Traceback (most recent call last):
  File "main.py", line 15, in <module>
    print ( G.f() )   # the number of faces
  File "/home/runner/graphs-dict/graphtheory/structures/graphs.py", line 52, in f
    raise ValueError("run planarity test first")
ValueError: run planarity test first
```