### PR TITLE
casted set to list on make_halin_outer required on Python3.11.6

### DIFF
--- a/graphtheory/planarity/halintools.py
+++ b/graphtheory/planarity/halintools.py
@@ -30,7 +30,7 @@ def make_halin_outer(n=4):
     nodes = set([0, 1, 2, 3])
     node = 4
     while node < n:
-        parent = random.sample(nodes, 1)[0]
+        parent = random.sample(sorted(nodes), 1)[0]
         if graph.degree(parent) == 1:   # leaf, we must add two edges
             if node + 1 == n:
                 continue


### PR DESCRIPTION
There was an error on make_halin_outer method, where the variable 'nodes' on the line parent = random.sample(nodes), 1)[0] was a Set object raising a Exception on Python 3.11.6.

If you run the original code on Python 3.11.6 the method random.sample() raise the Exception "TypeError: Population must be a sequence.  For dicts or sets, use sorted(d)."

After changing that line for parent = random.sample(sorted(nodes)), 1)[0] the code works properly.